### PR TITLE
Feature - PropTypes::exact() checker

### DIFF
--- a/src/Checkers/ShapeTypeChecker.php
+++ b/src/Checkers/ShapeTypeChecker.php
@@ -52,7 +52,7 @@ class ShapeTypeChecker implements TypeChecker
             $error = $checker->validate($prop_value, (string) $key, "{$prop_full_name}.{$key}");
 
             if ($error !== null) {
-                return $error;
+                return new PropTypeException($prop_name, 'invalid', $error->getMessage(), $error);
             }
         }
 

--- a/src/Checkers/StrictShapeTypeChecker.php
+++ b/src/Checkers/StrictShapeTypeChecker.php
@@ -1,0 +1,72 @@
+<?php
+namespace Prezly\PropTypes\Checkers;
+
+use InvalidArgumentException;
+use Prezly\PropTypes\Exceptions\PropTypeException;
+
+class StrictShapeTypeChecker implements TypeChecker
+{
+    /** @var \Prezly\PropTypes\Checkers\TypeChecker[] */
+    private $shape_types;
+
+    /**
+     * @param \Prezly\PropTypes\Checkers\TypeChecker[] $shape_types
+     */
+    public function __construct(array $shape_types)
+    {
+        foreach ($shape_types as $key => $checker) {
+            if (! $checker instanceof TypeChecker) {
+                throw new InvalidArgumentException(sprintf(
+                    'Invalid argument supplied to exact(). Expected an associative array of %s instances, but received %s at key "%s".',
+                    TypeChecker::class,
+                    is_object($checker) ? 'instance of ' . get_class($checker) : gettype($checker),
+                    $key
+                ));
+            }
+        }
+
+        $this->shape_types = $shape_types;
+    }
+
+    /**
+     * @param array $props
+     * @param string $prop_name
+     * @param string $prop_full_name
+     * @return \Prezly\PropTypes\Exceptions\PropTypeException|null Exception is returned if prop type is invalid
+     */
+    public function validate(array $props, string $prop_name, string $prop_full_name): ?PropTypeException
+    {
+        $prop_value = $props[$prop_name];
+
+        if (! is_array($prop_value)) {
+            $prop_type = gettype($prop_value);
+
+            return new PropTypeException(
+                $prop_name,
+                'invalid',
+                "Invalid property `{$prop_full_name}` of type `{$prop_type}` supplied, expected an associative array."
+            );
+        }
+
+        $all_keys = array_keys(array_merge($props, $this->shape_types));
+        foreach ($all_keys as $key) {
+            $checker = $this->shape_types[$key] ?? null;
+
+            if (empty($checker)) {
+                return new PropTypeException(
+                    $prop_name,
+                    'invalid',
+                    "Invalid property `{$prop_full_name}` with unexpected key `${key}` supplied."
+                );
+            }
+
+            $error = $checker->validate($prop_value, (string) $key, "{$prop_full_name}.{$key}");
+
+            if ($error !== null) {
+                return $error;
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/Checkers/StrictShapeTypeChecker.php
+++ b/src/Checkers/StrictShapeTypeChecker.php
@@ -48,7 +48,7 @@ class StrictShapeTypeChecker implements TypeChecker
             );
         }
 
-        $all_keys = array_keys(array_merge($props, $this->shape_types));
+        $all_keys = array_keys(array_merge($prop_value, $this->shape_types));
         foreach ($all_keys as $key) {
             $checker = $this->shape_types[$key] ?? null;
 

--- a/src/Checkers/StrictShapeTypeChecker.php
+++ b/src/Checkers/StrictShapeTypeChecker.php
@@ -48,7 +48,12 @@ class StrictShapeTypeChecker implements TypeChecker
             );
         }
 
-        $all_keys = array_keys(array_merge($prop_value, $this->shape_types));
+        $all_keys = array_unique(
+            array_merge(
+                array_keys($prop_value),
+                array_keys($this->shape_types)
+            )
+        );
         foreach ($all_keys as $key) {
             $checker = $this->shape_types[$key] ?? null;
 
@@ -63,7 +68,7 @@ class StrictShapeTypeChecker implements TypeChecker
             $error = $checker->validate($prop_value, (string) $key, "{$prop_full_name}.{$key}");
 
             if ($error !== null) {
-                return $error;
+                return new PropTypeException($prop_name, 'invalid', $error->getMessage(), $error);
             }
         }
 

--- a/src/PropTypes.php
+++ b/src/PropTypes.php
@@ -8,6 +8,7 @@ use Prezly\PropTypes\Checkers\ChainableTypeChecker;
 use Prezly\PropTypes\Checkers\InstanceTypeChecker;
 use Prezly\PropTypes\Checkers\PrimitiveTypeChecker;
 use Prezly\PropTypes\Checkers\ShapeTypeChecker;
+use Prezly\PropTypes\Checkers\StrictShapeTypeChecker;
 use Prezly\PropTypes\Checkers\TypeChecker;
 use Prezly\PropTypes\Exceptions\PropTypeException;
 
@@ -69,6 +70,11 @@ final class PropTypes
     public static function bool(): ChainableTypeChecker
     {
         return new ChainableTypeChecker(new PrimitiveTypeChecker('boolean'));
+    }
+
+    public static function exact(array $shape): ChainableTypeChecker
+    {
+        return new ChainableTypeChecker(new StrictShapeTypeChecker($shape));
     }
 
     public static function instanceOf(string $expected_class): ChainableTypeChecker

--- a/tests/Checkers/ShapeTypeCheckerTest.php
+++ b/tests/Checkers/ShapeTypeCheckerTest.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace Prezly\PropTypes\Tests\Checkers;
+
+use PHPUnit\Framework\TestCase;
+use Prezly\PropTypes\Checkers\PrimitiveTypeChecker;
+use Prezly\PropTypes\Checkers\ShapeTypeChecker;
+use Prezly\PropTypes\PropTypes;
+
+class ShapeTypeCheckerTest extends TestCase
+{
+    /**
+     * @test
+     * @dataProvider valid_examples
+     * @param array $shape
+     * @param mixed $value
+     */
+    public function it_should_pass_valid_values(array $shape, $value)
+    {
+        $error = (new ShapeTypeChecker($shape))->validate(['value' => $value], 'value', 'test.value');
+        $this->assertTrue($error === null);
+    }
+
+    /**
+     * @test
+     * @dataProvider invalid_examples
+     * @param array $shape
+     * @param mixed $value
+     */
+    public function it_should_return_error_for_invalid_values(
+        array $shape,
+        $value
+    ) {
+        $error = (new ShapeTypeChecker($shape))->validate(['value' => $value], 'value', 'test.value');
+        $this->assertNotNull($error);
+        // $this->assertEquals('value', $error->getPropName());
+        $this->assertEquals('invalid', $error->getErrorCode());
+    }
+
+    public function valid_examples(): iterable
+    {
+        yield 'empty shape requirements, empty array' => [
+            [],
+            []
+        ];
+
+        yield 'empty shape requirements, any array' => [
+            [],
+            ['anything' => 'goes', 'here' => '!']
+        ];
+
+        yield 'empty shape requirements, any numeric array' => [
+            [],
+            ['anything', 'goes', 'here', 200]
+        ];
+
+        yield 'arbitrary shape requirements' => [
+            ['name' => PropTypes::string()],
+            ['name' => 'Elvis Presley'],
+        ];
+
+        yield 'arbitrary shape requirements, array with extra props' => [
+            ['name' => PropTypes::string()],
+            ['name' => 'Elvis Presley', 'title' => 'The King'],
+        ];
+
+        yield 'tuple array requirements, tuple array' => [
+            [PropTypes::string(), PropTypes::string()],
+            ['Elvis Presley', 'The King'],
+        ];
+
+        yield 'tuple array requirements, tuple array with extra elements' => [
+            [PropTypes::string(), PropTypes::string()],
+            ['Elvis Presley', 'The King', null],
+        ];
+    }
+
+    public function invalid_examples(): iterable
+    {
+        yield 'empty shape requirements, not an array' => [
+            [],
+            1
+        ];
+
+        yield 'arbitrary shape requirements, empty array' => [
+            ['name' => PropTypes::string()->isRequired()],
+            []
+        ];
+
+        yield 'arbitrary shape requirements, array with missing prop' => [
+            ['name' => PropTypes::string()->isRequired()],
+            ['title' => 'The King'],
+        ];
+
+        yield 'tuple requirements, empty array' => [
+            [PropTypes::string()->isRequired()],
+            [],
+        ];
+
+        yield 'tuple requirements, array with not enough elements' => [
+            [PropTypes::string()->isRequired(), PropTypes::string()->isRequired()],
+            ['Elvis Presley']
+        ];
+    }
+}

--- a/tests/Checkers/StrictShapeTypeCheckerTest.php
+++ b/tests/Checkers/StrictShapeTypeCheckerTest.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace Prezly\PropTypes\Tests\Checkers;
+
+use PHPUnit\Framework\TestCase;
+use Prezly\PropTypes\Checkers\PrimitiveTypeChecker;
+use Prezly\PropTypes\Checkers\ShapeTypeChecker;
+use Prezly\PropTypes\Checkers\StrictShapeTypeChecker;
+use Prezly\PropTypes\PropTypes;
+
+class StrictShapeTypeCheckerTest extends TestCase
+{
+    /**
+     * @test
+     * @dataProvider valid_examples
+     * @param array $shape
+     * @param mixed $value
+     */
+    public function it_should_pass_valid_values(array $shape, $value)
+    {
+        $error = (new StrictShapeTypeChecker($shape))->validate(['value' => $value], 'value', 'test.value');
+        $this->assertNull($error);
+    }
+
+    /**
+     * @test
+     * @dataProvider invalid_examples
+     * @param array $shape
+     * @param mixed $value
+     */
+    public function it_should_return_error_for_invalid_values(
+        array $shape,
+        $value
+    ) {
+        $error = (new StrictShapeTypeChecker($shape))->validate(['value' => $value], 'value', 'test.value');
+        $this->assertNotNull($error);
+        // $this->assertEquals('value', $error->getPropName());
+        $this->assertEquals('invalid', $error->getErrorCode());
+    }
+
+    public function valid_examples(): iterable
+    {
+        yield 'empty shape requirements, empty array' => [
+            [],
+            []
+        ];
+
+        yield 'arbitrary shape requirements' => [
+            ['name' => PropTypes::string()],
+            ['name' => 'Elvis Presley'],
+        ];
+
+        yield 'tuple array requirements, tuple array' => [
+            [PropTypes::string(), PropTypes::string()],
+            ['Elvis Presley', 'The King'],
+        ];
+    }
+
+    public function invalid_examples(): iterable
+    {
+        yield 'empty shape requirements, not an array' => [
+            [],
+            1
+        ];
+
+        yield 'empty shape requirements, any array' => [
+            [],
+            ['anything' => 'goes', 'here' => '!']
+        ];
+
+        yield 'empty shape requirements, any numeric array' => [
+            [],
+            ['anything', 'goes', 'here', 200]
+        ];
+
+        yield 'arbitrary shape requirements, empty array' => [
+            ['name' => PropTypes::string()->isRequired()],
+            []
+        ];
+
+        yield 'arbitrary shape requirements, array with missing prop' => [
+            ['name' => PropTypes::string()->isRequired()],
+            ['title' => 'The King'],
+        ];
+
+        yield 'arbitrary shape requirements, array with extra props' => [
+            ['name' => PropTypes::string()],
+            ['name' => 'Elvis Presley', 'title' => 'The King'],
+        ];
+
+        yield 'tuple requirements, empty array' => [
+            [PropTypes::string()->isRequired()],
+            [],
+        ];
+
+        yield 'tuple requirements, array with not enough elements' => [
+            [PropTypes::string()->isRequired(), PropTypes::string()->isRequired()],
+            ['Elvis Presley']
+        ];
+
+        yield 'tuple array requirements, tuple array with extra elements' => [
+            [PropTypes::string(), PropTypes::string()],
+            ['Elvis Presley', 'The King', null],
+        ];
+    }
+}

--- a/tests/PropTypesTest.php
+++ b/tests/PropTypesTest.php
@@ -101,6 +101,17 @@ class PropTypesTest extends TestCase
                 'last' => 'Presley',
             ]]
         ];
+
+        yield 'exact' => [
+            ['name' => PropTypes::shape([
+                'first' => PropTypes::string()->isRequired(),
+                'last' => PropTypes::string()->isRequired(),
+            ])],
+            ['name' => [
+                'first' => 'Elvis',
+                'last' => 'Presley',
+            ]]
+        ];
     }
 
     public function invalid_data_examples(): iterable
@@ -132,24 +143,13 @@ class PropTypesTest extends TestCase
             ])],
             ['name' => 'Elvis Presley'],
         ];
-        yield 'shape: required prop missing' => [
+
+        yield 'exact: not a shape' => [
             ['name' => PropTypes::shape([
                 'first' => PropTypes::string()->isRequired(),
                 'last' => PropTypes::string()->isRequired(),
             ])],
-            ['name' => [
-                'first' => 'Elvis',
-            ]],
-        ];
-        yield 'shape: incorrect prop type' => [
-            ['name' => PropTypes::shape([
-                'first' => PropTypes::string()->isRequired(),
-                'last' => PropTypes::string()->isRequired(),
-            ])],
-            ['name' => [
-                'first' => 'Elvis',
-                'last' => 42,
-            ]],
+            ['name' => 'Elvis Presley'],
         ];
     }
 }

--- a/tests/PropTypesTest.php
+++ b/tests/PropTypesTest.php
@@ -17,13 +17,14 @@ class PropTypesTest extends TestCase
         $this->assertInstanceOf(ChainableTypeChecker::class, PropTypes::array());
         $this->assertInstanceOf(ChainableTypeChecker::class, PropTypes::arrayOf(PropTypes::any()));
         $this->assertInstanceOf(ChainableTypeChecker::class, PropTypes::bool());
+        $this->assertInstanceOf(ChainableTypeChecker::class, PropTypes::exact([]));
         $this->assertInstanceOf(ChainableTypeChecker::class, PropTypes::instanceOf(self::class));
         $this->assertInstanceOf(ChainableTypeChecker::class, PropTypes::int());
         $this->assertInstanceOf(ChainableTypeChecker::class, PropTypes::float());
         $this->assertInstanceOf(ChainableTypeChecker::class, PropTypes::null());
         $this->assertInstanceOf(ChainableTypeChecker::class, PropTypes::object());
-        $this->assertInstanceOf(ChainableTypeChecker::class, PropTypes::string());
         $this->assertInstanceOf(ChainableTypeChecker::class, PropTypes::shape([]));
+        $this->assertInstanceOf(ChainableTypeChecker::class, PropTypes::string());
     }
 
     /**


### PR DESCRIPTION
Fixes #5 

- Add `StrictShapeTypeChecker`
- Add tests for both `StrictShapeTypeChecker` and `ShapeTypeChecker`
- Wrap errors from shape checkers