### PR TITLE
Feature - Option to allow extra properties

### DIFF
--- a/src/PropTypes.php
+++ b/src/PropTypes.php
@@ -17,14 +17,22 @@ use Prezly\PropTypes\Exceptions\PropTypeException;
 
 final class PropTypes
 {
+    const DEFAULT_OPTIONS = [
+        'allow_extra_properties' => false,
+    ];
+
     /**
      * @param \Prezly\PropTypes\Checkers\TypeChecker[] $specs
      * @param array $values
+     * @param array $options
+     *        - bool "allow_extra_properties" (default: false)
      * @throws \Prezly\PropTypes\Exceptions\PropTypeException When a prop-type validation fails.
      * @throws \InvalidArgumentException When invalid specs configuration was given.
      */
-    public static function checkPropTypes(array $specs, array $values): void
+    public static function check(array $specs, array $values, array $options = []): void
     {
+        $options = array_merge(self::DEFAULT_OPTIONS, $options);
+
         foreach ($specs as $key => $checker) {
             if (! $checker instanceof TypeChecker) {
                 throw new InvalidArgumentException(sprintf(
@@ -37,13 +45,15 @@ final class PropTypes
             }
         }
 
-        foreach (array_keys($values) as $prop_name) {
-            if (! isset($specs[$prop_name])) {
-                throw new PropTypeException(
-                    $prop_name,
-                    'unexpected_extra_property',
-                    "Unexpected extra property `{$prop_name}` supplied."
-                );
+        if (! $options['allow_extra_properties']) {
+            foreach (array_keys($values) as $prop_name) {
+                if (! isset($specs[$prop_name])) {
+                    throw new PropTypeException(
+                        $prop_name,
+                        'unexpected_extra_property',
+                        "Unexpected extra property `{$prop_name}` supplied."
+                    );
+                }
             }
         }
 

--- a/tests/PropTypesTest.php
+++ b/tests/PropTypesTest.php
@@ -37,7 +37,7 @@ class PropTypesTest extends TestCase
      */
     public function it_should_silently_pass_valid_data(array $specs, array $values)
     {
-        PropTypes::checkPropTypes($specs, $values);
+        PropTypes::check($specs, $values);
         $this->assertTrue(true, "PropTypes::checkPropTypes didn't throw an exception");
     }
 
@@ -50,7 +50,7 @@ class PropTypesTest extends TestCase
     public function it_should_throw_on_invalid_data(array $specs, array $values)
     {
         $this->expectException(PropTypeException::class);
-        PropTypes::checkPropTypes($specs, $values);
+        PropTypes::check($specs, $values);
     }
 
     /**
@@ -59,7 +59,7 @@ class PropTypesTest extends TestCase
     public function it_should_throw_on_unexpected_extra_properties()
     {
         try {
-            PropTypes::checkPropTypes([
+            PropTypes::check([
                 'name' => PropTypes::any(),
             ], [
                 'name' => 'Elvis Presley',
@@ -71,6 +71,23 @@ class PropTypesTest extends TestCase
             $this->assertEquals('unexpected_extra_property', $error->getErrorCode());
             $this->assertEquals('Unexpected extra property `job` supplied.', $error->getMessage());
         }
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_allow_extra_properties_if_configured()
+    {
+        PropTypes::check([
+            'name' => PropTypes::any(),
+        ], [
+            'name' => 'Elvis Presley',
+            'job'  => 'The King',
+        ], [
+            'allow_extra_properties' => true,
+        ]);
+
+        $this->assertTrue(true);
     }
 
     public function valid_data_examples(): iterable


### PR DESCRIPTION
Fixes #2 

- Rename `PropTypes::checkPropTypes()` to `PropTypes::check()`
- Add an option to allow extra properties: `allow_extra_properties`

See https://github.com/prezly/prop-types-php/issues/2#issue-541351576