### PR TITLE
Feature - PropTypes::equals() type-checker

### DIFF
--- a/src/Checkers/EqualityTypeChecker.php
+++ b/src/Checkers/EqualityTypeChecker.php
@@ -1,0 +1,129 @@
+<?php
+
+namespace Prezly\PropTypes\Checkers;
+
+use Prezly\PropTypes\Exceptions\PropTypeException;
+use stdClass;
+
+final class EqualityTypeChecker implements TypeChecker
+{
+    /** @var mixed */
+    private $expected_value;
+
+    /**
+     * @param  mixed  $expected_value
+     * @param  bool  $strict
+     */
+    public function __construct($expected_value)
+    {
+        $this->expected_value = $expected_value;
+    }
+
+    /**
+     * @param array $props
+     * @param string $prop_name
+     * @param string $prop_full_name
+     * @return \Prezly\PropTypes\Exceptions\PropTypeException|null Exception is returned if prop type is invalid
+     */
+    public function validate(array $props, string $prop_name, string $prop_full_name): ?PropTypeException
+    {
+        $prop_value = $props[$prop_name];
+
+        // Compare objects with "=="
+        if (is_object($this->expected_value) && $this->expected_value == $prop_value) {
+            return null;
+        }
+
+        // Compare everything else with "==="
+        if ($this->expected_value === $prop_value) {
+            return null;
+        }
+
+        $expected = self::stringifyValue($this->expected_value);
+        $actual = self::stringifyValue($prop_value);
+
+        return new PropTypeException(
+            $prop_name,
+            "Invalid property `{$prop_full_name}` of value `{$actual}` supplied, expected: {$expected}."
+        );
+    }
+
+    /**
+     * @param mixed $value
+     * @return string
+     */
+    private static function stringifyValue($value): string
+    {
+        if (is_null($value)) {
+            return 'null';
+        }
+
+        if (is_bool($value)) {
+            return $value ? 'true' : 'false';
+        }
+
+        if (is_int($value) || is_float($value)) {
+            return (string) $value;
+        }
+
+        if (is_resource($value)) {
+            return 'resource';
+        }
+
+        if (is_string($value)) {
+            if (mb_strlen($value) > 100) {
+                return sprintf('"%s..." (%s characters)', mb_substr($value, 0, 80), mb_strlen($value));
+            }
+            return sprintf('"%s"', $value);
+        }
+
+        if (is_array($value)) {
+            return self::stringifyArray($value);
+        }
+
+        if (is_object($value)) {
+            return self::stringifyInstance($value);
+        }
+
+        return (string) $value;
+    }
+
+    /**
+     * @param object $value
+     * @return string
+     */
+    private static function stringifyInstance($value): string
+    {
+        if ($value instanceof stdClass) {
+            return sprintf('object %s', self::stringifyObject($value));
+        }
+
+        $class = get_class($value);
+        if (method_exists($value, '__toString')) {
+            return "instance of {$class} ({$value->__toString()})";
+        }
+        return "instance of {$class}";
+    }
+
+    private static function stringifyObject(stdClass $value): string
+    {
+        $struct = array_map(function ($value) {
+            return self::stringifyValue($value);
+        }, (array) $value);
+
+        $pairs = [];
+        foreach ($struct as $property => $value) {
+            $pairs[] = "{$property}: {$value}";
+        }
+        return sprintf('{%s}', implode(', ', $pairs));
+    }
+
+    private static function stringifyArray(array $value): string
+    {
+        $values = array_map(function ($value) {
+            return self::stringifyValue($value);
+        }, $value);
+
+        return sprintf('[%s]', implode(', ', $values));
+    }
+}

--- a/src/PropTypes.php
+++ b/src/PropTypes.php
@@ -8,6 +8,7 @@ use Prezly\PropTypes\Checkers\CallableTypeChecker;
 use Prezly\PropTypes\Checkers\CallbackTypeChecker;
 use Prezly\PropTypes\Checkers\ChainableTypeChecker;
 use Prezly\PropTypes\Checkers\EnumTypeChecker;
+use Prezly\PropTypes\Checkers\EqualityTypeChecker;
 use Prezly\PropTypes\Checkers\InstanceTypeChecker;
 use Prezly\PropTypes\Checkers\PrimitiveTypeChecker;
 use Prezly\PropTypes\Checkers\ShapeTypeChecker;
@@ -63,6 +64,16 @@ class PropTypes
                 throw $error;
             }
         }
+    }
+
+    public static function equals($value): ChainableTypeChecker
+    {
+        $checker = new ChainableTypeChecker(new EqualityTypeChecker($value));
+
+        // No need to initially forbid null,
+        // as equality check will reject null value,
+        // unless it is expected.
+        return $checker->isNullable();
     }
 
     public static function any(): ChainableTypeChecker

--- a/tests/Checkers/EqualityTypeCheckerTest.php
+++ b/tests/Checkers/EqualityTypeCheckerTest.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Prezly\PropTypes\Tests\Checkers;
+
+use PHPUnit\Framework\TestCase;
+use Prezly\PropTypes\Checkers\EqualityTypeChecker;
+
+final class EqualityTypeCheckerTest extends TestCase
+{
+    /**
+     * @test
+     * @dataProvider valid_examples
+     * @param mixed $expected_value
+     * @param mixed $value
+     */
+    public function it_should_pass_valid_values($expected_value, $value = null)
+    {
+        $value = $value ?? $expected_value;
+
+        $error = (new EqualityTypeChecker($expected_value))->validate(['value' => $value], 'value', 'value');
+        $this->assertNull($error);
+    }
+
+    /**
+     * @test
+     * @dataProvider invalid_examples
+     * @param  mixed  $expected_value
+     * @param  mixed  $value
+     * @param  string  $expected_error
+     */
+    public function it_should_return_error_for_invalid_values($expected_value, $value, string $expected_error)
+    {
+        $error = (new EqualityTypeChecker($expected_value))->validate(['value' => $value], 'value', 'test.value');
+        $this->assertNotNull($error);
+        $this->assertSame('value', $error->getPropName());
+        $this->assertSame($expected_error, $error->getMessage());
+    }
+
+    public function valid_examples(): iterable
+    {
+        yield 'a null' => [null];
+        yield 'a string' => ['c'];
+        yield 'a number' => [10];
+        yield 'an instance' => [$this];
+        yield 'a bool' => [true];
+        yield 'an array' => [[1, 2]];
+        yield 'an object' => [(object) ['name' => 'Elvis'], (object) ['name' => 'Elvis']];
+    }
+
+    public function invalid_examples(): iterable
+    {
+        yield 'a string' => [
+            'a',
+            'd',
+            'Invalid property `test.value` of value `"d"` supplied, expected: "a".',
+        ];
+        yield 'a number' => [
+            1,
+            5,
+            'Invalid property `test.value` of value `5` supplied, expected: 1.',
+        ];
+        yield 'an instance' => [
+            (object) ['name' => 'Elvis'],
+            (object) ['name' => 'Melvis'],
+            'Invalid property `test.value` of value `object {name: "Melvis"}` supplied, expected: object {name: "Elvis"}.',
+        ];
+        yield 'a bool' => [
+            true,
+            false,
+            'Invalid property `test.value` of value `false` supplied, expected: true.',
+        ];
+        yield 'an array' => [
+            [1, 2, 3],
+            [1, 2, 4],
+            'Invalid property `test.value` of value `[1, 2, 4]` supplied, expected: [1, 2, 3].',
+        ];
+        yield 'a resource' => [
+            fopen('php://temp', 'r'),
+            fopen('php://stdin', 'r'),
+            'Invalid property `test.value` of value `resource` supplied, expected: resource.'
+        ];
+    }
+}

--- a/tests/PropTypesTest.php
+++ b/tests/PropTypesTest.php
@@ -6,7 +6,7 @@ use Prezly\PropTypes\Checkers\ChainableTypeChecker;
 use Prezly\PropTypes\Exceptions\PropTypeException;
 use Prezly\PropTypes\PropTypes;
 
-class PropTypesTest extends TestCase
+final class PropTypesTest extends TestCase
 {
     /**
      * @test
@@ -102,6 +102,26 @@ class PropTypesTest extends TestCase
         yield 'any: optional' => [
             ['name' => PropTypes::any()->isOptional()],
             [],
+        ];
+
+        yield 'equals: null' => [
+            ['type' => PropTypes::equals(null)],
+            ['type' => null],
+        ];
+
+        yield 'equals: string' => [
+            ['type' => PropTypes::equals('object')],
+            ['type' => 'object'],
+        ];
+
+        yield 'equals: int' => [
+            ['count' => PropTypes::equals(500)],
+            ['count' => 500],
+        ];
+
+        yield 'equals: array' => [
+            ['tags' => PropTypes::equals(['a', 'b', 'c'])],
+            ['tags' => ['a', 'b', 'c']],
         ];
 
         yield 'arrayOf: string' => [


### PR DESCRIPTION
- Implement `PropTypes::equals()` type-checker
  Technically it is a partial case of `::oneOf()`, still convenient to have.