### PR TITLE
Fix - Behavior on rejecting nulls

### DIFF
--- a/src/Checkers/ChainableTypeChecker.php
+++ b/src/Checkers/ChainableTypeChecker.php
@@ -41,6 +41,11 @@ final class ChainableTypeChecker implements TypeChecker
 
         if ($props[$prop_name] === null) {
             if (! $this->is_nullable) {
+                // If nested checker allows NULL, we allow it too.
+                if ($this->checker->validate($props, $prop_name, $prop_full_name) === null) {
+                    return null;
+                }
+
                 return new PropTypeException(
                     $prop_name,
                     "The property `{$prop_full_name}` is marked as not-null, but its value is `null`."

--- a/src/PropTypes.php
+++ b/src/PropTypes.php
@@ -68,12 +68,7 @@ class PropTypes
 
     public static function equals($value): ChainableTypeChecker
     {
-        $checker = new ChainableTypeChecker(new EqualityTypeChecker($value));
-
-        // No need to initially forbid null,
-        // as equality check will reject null value,
-        // unless it is expected.
-        return $checker->isNullable();
+        return new ChainableTypeChecker(new EqualityTypeChecker($value));
     }
 
     public static function any(): ChainableTypeChecker

--- a/tests/Checkers/ChainableTypeCheckerTest.php
+++ b/tests/Checkers/ChainableTypeCheckerTest.php
@@ -6,6 +6,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Prezly\PropTypes\Checkers\ChainableTypeChecker;
 use Prezly\PropTypes\Checkers\TypeChecker;
+use Prezly\PropTypes\Exceptions\PropTypeException;
 
 final class ChainableTypeCheckerTest extends TestCase
 {
@@ -43,7 +44,9 @@ final class ChainableTypeCheckerTest extends TestCase
     public function it_should_not_allow_nulls_by_default()
     {
         $checker = new ChainableTypeChecker($this->mockChecker(function (MockObject $mock) {
-            $mock->expects(self::never())->method('validate');
+            $mock->expects(self::any())
+                ->method('validate')
+                ->willReturn(new PropTypeException('name', 'Invalid'));
         }));
         $error = $checker->validate(['name' => 'Elvis', 'job' => null], 'job', 'job');
         $this->assertNotNull($error);

--- a/tests/PropTypesTest.php
+++ b/tests/PropTypesTest.php
@@ -96,7 +96,7 @@ final class PropTypesTest extends TestCase
             ['name' => 'Elvis Presley'],
         ];
         yield 'any: null' => [
-            ['name' => PropTypes::any()->isNullable()],
+            ['name' => PropTypes::any()],
             ['name' => null],
         ];
         yield 'any: optional' => [
@@ -112,6 +112,11 @@ final class PropTypesTest extends TestCase
         yield 'equals: string' => [
             ['type' => PropTypes::equals('object')],
             ['type' => 'object'],
+        ];
+
+        yield 'equals: nullable string' => [
+            ['type' => PropTypes::equals('object')->isNullable()],
+            ['type' => null],
         ];
 
         yield 'equals: int' => [
@@ -175,14 +180,14 @@ final class PropTypesTest extends TestCase
 
     public function invalid_data_examples(): iterable
     {
-        yield 'any: null when not-nullable' => [
-            ['name' => PropTypes::any()],
-            ['name' => null],
-        ];
-
         yield 'any: missing when required' => [
             ['name' => PropTypes::any()],
             [],
+        ];
+
+        yield 'equals: non-nullable string' => [
+            ['type' => PropTypes::equals('object')],
+            ['type' => null],
         ];
 
         yield 'extra property "occupation"' => [


### PR DESCRIPTION
Fix ChainableTypeChecker behaviour on rejecting nulls.

Consider the following case:

```php
PropTypes::check([
    'type' => PropTypes::oneOf(['object', null]),
    'error' => PropTypes::equals(null),
], [
    'type' => null,
    'error' => null,
]);
```

**Previous behavior**
Throws an exception, as `nulls` are not allowed by `ChainableTypeChecker` that wraps properties checkers.

**Fixed behavior**
Passes. As `nulls` are allowed by nested properties checkers, which `ChainableTypeChecker` does now respect.
